### PR TITLE
Automagically detect latest P2Pool tag and use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG P2POOL_BRANCH=v3.1
-
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build
 LABEL author="sethforprivacy@protonmail.com" \
@@ -22,9 +20,14 @@ ENV BOOST_DEBUG         1
 # Switch to p2pool source directory
 WORKDIR /p2pool
 
+# Git pull p2pool source to determine latest tag/branch
+RUN git clone https://github.com/SChernykh/p2pool .
+
 # Git pull p2pool source at specified tag/branch
-ARG P2POOL_BRANCH
-RUN git clone --recursive --branch ${P2POOL_BRANCH} https://github.com/SChernykh/p2pool .
+RUN export P2POOL_BRANCH=$(git log --tags --simplify-by-decoration --pretty="format:%ai %d" |sort -r|grep 'tag:'|head -n1|sed -r 's/^.*tag: ([^\)]*)\)/\1/g') && \
+    git checkout ${P2POOL_BRANCH} && \
+    git submodule init && \
+    git submodule update --recursive
 
 # Make static p2pool binary
 ARG NPROC


### PR DESCRIPTION
Checks out P2Pool repository without recursive options, detect which is the latest tag created by extracting tag version from log commit date sorted information.