### PR TITLE
Update P2Pool v3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v3.6.1
+ARG P2POOL_BRANCH=v3.6.2
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
[Release Notes](https://github.com/SChernykh/p2pool/releases/tag/v3.6.2)

As the release notes say, it's not really needed in this docker image, because there are no code changes.