### PR TITLE
Bump to v3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v3.9
+ARG P2POOL_BRANCH=v3.10
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
Changes in v3.10

New features:

    Updated RandomX code to v1.2.1
    Added RISC-V build

Bugfixes:

    Fixed Peers could ban each other erroneously for "not broadcasting blocks"
    Fixed incorrect timing values when logging found shares