### PR TITLE
bump p2pool to v4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v3.10
+ARG P2POOL_BRANCH=v4.0
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
[Commits to master since this release](https://github.com/SChernykh/p2pool/compare/v4.0...master)
P2Pool (not Monero!) will hardfork to new consensus rules on October 12th, 2024 at 20:00 UTC. Merge mining will be enabled at that time. You must update to P2Pool v4.0 or newer before this date.

Changes in v4.0

New features:

    [Merge mining support](https://github.com/SChernykh/p2pool?tab=readme-ov-file#merge-mining) (available after the fork)
    Stratum: calculate hashing blobs in parallel (improved performance with high number of connected miners)
    Stratum: autodiff will use 500k starting difficulty now for faster adjustment

Bugfixes:

    Updated internal dependencies to the latest versions (curl to 8.8.0, libuv to 1.48, miniupnp and libzmq to the lastest master branch)
    Exit early with an error message if the command line is invalid, P2Pool will not try to start in this case
    Fixed a few rare crashes and data races

Before you start mining, create a new wallet and don't use it for anything else but mining for privacy reasons - all wallet addresses are public on P2Pool! Only primary wallet address is supported - no subaddresses or integrated addresses.

It is strongly recommended to synchronize your system clock before you start mining!
Recommended monerod command line parameters:

./monerod --zmq-pub tcp://127.0.0.1:18083 --out-peers 32 --in-peers 64 --add-priority-node=p2pmd.xmrvsbeast.com:18080 --add-priority-node=nodes.hashvault.pro:18080 --disable-dns-checkpoints --enable-dns-blocklist

--out-peers 32 --in-peers 64 is needed to (1) have many connections to other nodes and (2) limit incoming connection count because it can grow uncontrollably and cause problems when it goes above 1000 (open files limit in Linux). If your network connection's upload bandwidth is less than 10 Mbit, use --out-peers 8 --in-peers 16 instead.

--add-priority-node=p2pmd.xmrvsbeast.com:18080 --add-priority-node=nodes.hashvault.pro:18080 is needed to have guaranteed good working nodes in your connected peers.

--disable-dns-checkpoints is needed to avoid periodical lags when DNS is updated (it's not needed when mining)
--enable-dns-blocklist is needed to ban known bad nodes

Usage:

    Run Monero daemon v0.18.3.3 or newer: ./monerod --zmq-pub tcp://127.0.0.1:18083 --out-peers 32 --in-peers 64 --add-priority-node=p2pmd.xmrvsbeast.com:18080 --add-priority-node=nodes.hashvault.pro:18080 --disable-dns-checkpoints --enable-dns-blocklist
    Run p2pool: ./p2pool --host 127.0.0.1 --wallet YOUR_WALLET_ADDRESS
    Start mining to port 3333 on your machine: ./xmrig -o 127.0.0.1:3333
    You can set custom difficulty for your miner to get more accurate stats on P2Pool side: ./xmrig -o 127.0.0.1:3333 -u x+50000 (it doesn't affect mining rewards in any way)
    To connect another mining rig to your P2Pool node, run ./xmrig -o YOUR_P2POOL_NODE_IP:3333 on that mining rig

Antivirus

Some antiviruses and firewalls may flag any Monero-related executables and archives, including P2Pool, as malware. This is because it contains RandomX mining code and therefore is considered as "mining software". To be sure that you downloaded the original binaries, always check SHA256 sums of what you downloaded - a GPG signed list of SHA256 sums is in sha256sums.txt.asc. You can read the instructions on how to do it here: https://www.getmonero.org/resources/user-guides/verification-windows-beginner.html - but to check P2Pool binaries, replace binaryFate's key with the GPG key provided here:

    GPG key to verify SHA256 sums can be downloaded from [github](https://raw.githubusercontent.com/monero-project/gitian.sigs/master/gitian-pubkeys/SChernykh.asc) or [p2pool.io](https://p2pool.io/SChernykh.asc)