### PR TITLE
bump p2pool to v4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.0
+ARG P2POOL_BRANCH=v4.1
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
P2Pool will hardfork to new consensus rules on October 12th, 2024 at 20:00 UTC (note that only P2Pool will hardfork, Monero blockchain will not hardfork on October 12th). Merge mining will be enabled at that time. You must update to P2Pool v4.0 or newer before this date.

**Changes in v4.1**

**New features**:

- Stratum: added SSL/TLS support for stratum connections
- New command line parameters --tls-cert and --tls-cert-key - see [documentation](https://github.com/SChernykh/p2pool/blob/v4.1/docs/COMMAND_LINE.MD)
- Stratum: detect HTTP requests to the stratum port and send a P2Pool Stratum online response (useful for quick checks in a browser)

**Bugfixes**:
- Fixed a random failure to start on some Windows systems because of failed to bind port ... for ZMQ publisher errors
- Fixed an occasional deadlock on exit with merge mining active
- Updated internal dependencies to the latest versions (curl to 8.9.1, gRPC to v1.65.4, miniupnp to the latest master branch)
- P2Pool API: skip unnecessary file writes