### PR TITLE
Bump to v4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.1.1
+ARG P2POOL_BRANCH=v4.2
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
Changes in v4.2

New features:
- Stratum server now disconnects miners when it's not connected to P2Pool network to avoid wasting their hashrate
- Added an error code to error messages about opening/saving files

Bugfixes:
- Fixed a possible deadlock during the initial sync when a lot of hashrate (> 1 MH/s) is connected to Stratum (this bug was introduced in v4.0)
- Fixed Windows 7 compatibility
- Fixed a data race on shutdown
- Updated internal dependencies (libuv to v1.49.2)