### PR TITLE
Bump to v4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.4
+ARG P2POOL_BRANCH=v4.5
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
**Changes in v4.5**

New features:

- Switch to another host during startup if the first host is unavailable and multiple host are specified
- Set thread names for better debugging

Bugfixes:

- Fixed build flags for the release binaries (most of the 3rd-party code wasn't optimized in previous releases)
- Fixed a crash in RISC-V build when huge pages are not available
- Logging: fixed unsafe memory read
- Fixed unaligned memory accesses
- ZMQ: fixed connect detection (It could give a false negative if the connection took >= 1000 ms)
- Added a workaround for broken OS implementations of /dev/random
- Updated internal dependencies (curl to 8.13.0, libuv to v1.51.0, miniupnp to the latest master)