### PR TITLE
Bump p2pool to v4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.6
+ARG P2POOL_BRANCH=v4.7
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
**Changes in v4.7**

New features:

- P2Pool-nano support (new --nano command line parameter)

Bugfixes:

- More robust startup sequence: if failed to download block headers - retry, don't abort. Also do requests in the correct order.
- P2Pool-nano: fixed warnings during startup
- Fix: failure to connect to a node if its domain resolves to an IPv6 address
- Tari: fixed max gRPC message size (sometimes P2Pool was unable to get new tasks from the Tari node)
- Updated internal dependencies (curl to 8.14.0, cppzmq and miniupnp to the latest master)