### PR TITLE
Bump p2pool to v4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.7
+ARG P2POOL_BRANCH=v4.8
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
**Changes in v4.8**

**A number of security issues were found and fixed in the console commands code. It is recommended to update to v4.8**

**Security fixes:**

- Console: limit access via local TCP port. It was possible for local users to send console commands to a running P2Pool instance without any user access checks. Now only a user with read access to P2Pool's local API files can do it.
- Console: don't listen on a local TCP port when local API is not enabled
- Console: don't let random unformatted data end up in the log

**New features:**

- Added --stratum-ban-time option to configure the ban time of stratum clients
- API: add last_share_found_time in local/stratum
- API: added merge mining data to the api_folder/local/merge_mining path
- Tari: added "block push via gRPC" functionality for better block propagation

**Bugfixes:**

- Log: always reopen the log file on SIGUSR1
- TCPServer: fixed SOCKS5 error checking logic
- Fixed host ping time calculation when using SOCKS5 proxy
- Correct unit prefix symbol for unit 'kilohash per second'
- Correct unit prefix symbol for unit 'mebibyte'
- Don't use outdated merge mining data (more than 30 minutes old) and warn the user in the log
- Get a new merge mining block template immediately after submitting a block, don't wait for a polling interval timeout
- Updated internal dependencies (curl to 8.14.1)

Special thanks to [Low-power](https://github.com/SChernykh/p2pool/commits?author=Low-power) for contributions to this release.