### PR TITLE
Bump P2Pool to version 4.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG P2POOL_BRANCH=v4.15.1
+ARG P2POOL_BRANCH=v4.16
 
 # Select latest Ubuntu LTS for the build image base
 FROM ubuntu:latest as build


### PR DESCRIPTION
Bumps `P2POOL_BRANCH` from `v4.15.1` to `v4.16`.

> **Note:** A consensus vulnerability was found and fixed in v4.16. It is **strongly recommended** to update.

## Highlights from the [v4.16 release notes](https://github.com/SChernykh/p2pool/releases/tag/v4.16)

### Security fixes
- Consensus vulnerability fixed (details will be published later)

### New features
- Display node's RPC SSL fingerprint when connecting with SSL
- Added TLS support to merge mining (JSON RPC)
- Merge mining (JSON RPC): added more API fields for better UX
- Added "stuck" detection to `status` command's node health rating

### Bugfixes
- P2PServer: multiple fixes and overall hardening of the network code
- StratumServer: enforce min diff = 1000 in all cases
- Miner: update api correctly when stopped
- Miner: update api's `total_hashes` to a correct value when stopped

Full diff: https://github.com/SChernykh/p2pool/compare/v4.15.1...v4.16