### PR TITLE
chore: purge old sethsimmons handle/branding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Seth Simmons (@sethsimmons)
+Copyright (c) 2021 Seth For Privacy (@sethforprivacy)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Purges references to the old `sethsimmons` handle / `sethsimmons.me` blog as part of rebranding to Seth For Privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)