### PR TITLE
Add Renovate config for automated p2pool version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    "mergeConfidence:all-badges",
+    ":disableRateLimiting",
+    ":semanticCommits"
+  ],
+  "rebaseWhen": "conflicted",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)(\\sARG .*?_CHECKSUM=(?<currentDigest>.*))?\\s",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_BRANCH=(?<currentValue>.*)(\\sARG .*?_COMMIT_HASH=(?<currentDigest>.*))?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{/if}}"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=github-releases depName=SChernykh/p2pool
 ARG P2POOL_BRANCH=v4.17
 
 # Select latest Ubuntu LTS for the build image base


### PR DESCRIPTION
## Summary

Sets up automated dependency updates via Renovate, modeled on the gold-standard config in [`sethforprivacy/simple-monerod-docker`](https://github.com/sethforprivacy/simple-monerod-docker).

## Changes

1. **`.github/renovate.json`** — same `extends` preset and `customManager` regex as the monerod repo. The custom manager already matches `ARG ..._BRANCH=<value>` lines, so it tracks `P2POOL_BRANCH` directly. With `docker:enableMajor`, the built-in docker manager will also keep the pinned `ubuntu` base image current.

2. **Dockerfile annotation** — adds
   ```
   # renovate: datasource=github-releases depName=SChernykh/p2pool
   ```
   immediately above `ARG P2POOL_BRANCH=v4.17`. This tells the custom manager to look up new p2pool releases from GitHub.

## Validation

Validated with `renovate-config-validator` (renovate@latest):

```
INFO: Config validated successfully against 1 file(s)
```

> Note: `managerFilePatterns` is the current field name (renamed from `fileMatch`) and requires Renovate ≥ 39. An older cached `renovate@37` validator rejects it, but the hosted Mend Renovate app on this owner runs a current version — this is identical to the field used in the live monerod config.

## Rollout

The hosted Mend Renovate app is already active on this owner's repos and will pick this config up automatically once merged. No CI build is triggered by this PR's renovate.json (the test-build workflow filters on `Dockerfile`); the 1-line annotation does touch the Dockerfile and will trigger a no-op-equivalent test build.