### PR TITLE
Fix legacy Dockerfile syntax flagged by BuildKit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG P2POOL_BRANCH=v4.17
 
 # Pin to the latest Ubuntu LTS for the build image base (kept current by Renovate)
-FROM ubuntu:26.04 as build
+FROM ubuntu:26.04 AS build
 LABEL author="sethforprivacy@protonmail.com" \
       maintainer="sethforprivacy@protonmail.com"
 
@@ -17,8 +17,8 @@ RUN apt-get update \
 
 ENV CFLAGS='-fPIC'
 ENV CXXFLAGS='-fPIC'
-ENV USE_SINGLE_BUILDDIR 1
-ENV BOOST_DEBUG         1
+ENV USE_SINGLE_BUILDDIR=1
+ENV BOOST_DEBUG=1
 
 # Switch to p2pool source directory
 WORKDIR /p2pool


### PR DESCRIPTION
## Summary
`docker build --check` reported 3 deprecation warnings on the Dockerfile. This resolves them with no functional change:

- `FROM ubuntu:26.04 as build` → `AS build` — [FromAsCasing](https://docs.docker.com/go/dockerfile/rule/from-as-casing/)
- `ENV USE_SINGLE_BUILDDIR 1` → `ENV USE_SINGLE_BUILDDIR=1` — [LegacyKeyValueFormat](https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/)
- `ENV BOOST_DEBUG 1` → `ENV BOOST_DEBUG=1` — same

## Verification
`docker build --check` now reports **no warnings**. The space- and `=`-forms of single-value `ENV` are semantically identical and `as`/`AS` is purely casing, so the build is unaffected.

## Other repos
Checked all four with `docker build --check`; monerod, docker-bitcoind, and monero-wallet-rpc are already clean — p2pool was the only one with legacy syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)