### PR TITLE
security: pin p2pool source commit, digest bases, trivy/SBOM/cosign gate, compose loopback

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# VCS and CI metadata
+.git
+.github
+.claude
+
+# Docs and local examples — not part of the image build
+README.md
+LICENSE
+examples/

--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,4 +1,0 @@
-general:
-  vulnerabilities:
-    - CIS-DI-0005
-    - CIS-DI-0008

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -71,10 +71,29 @@ jobs:
           outputs: type=image,"name=${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ env.PLATFORM }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
           cache-from: |
             type=registry,ref=${{ env.GHCR_REPO }}:buildcache-${{ env.DIGEST_NAME }}
             type=registry,ref=${{ env.GHCR_REPO }}:latest
           cache-to: type=registry,ref=${{ env.GHCR_REPO }}:buildcache-${{ env.DIGEST_NAME }},mode=max
+
+      # Fail the release on critical/high vulnerabilities that already have fixes
+      - name: Scan pushed image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.GHCR_REPO }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          scan-type: image
+        env:
+          # Each matrix job pushes a single-arch index (image + attestations);
+          # trivy's remote resolver defaults to linux/amd64 and fatals on the
+          # arm64 index. trivy-action v0.36.0 declares no `options` input, so
+          # pin the platform via Trivy's environment configuration.
+          TRIVY_PLATFORM: linux/${{ env.DIGEST_NAME }}
 
       # Smoke-test the exact artifact that was just pushed, BEFORE the merge job
       # tags it `latest`. If this fails, the merge job (needs: build) never runs.
@@ -123,6 +142,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -169,3 +189,10 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless signature over the final multi-arch manifest (Fulcio/Rekor OIDC)
+      - name: Sign the published image
+        run: cosign sign --yes "${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # renovate: datasource=github-releases depName=SChernykh/p2pool
 ARG P2POOL_BRANCH=v4.18
+ARG P2POOL_COMMIT_HASH=1748daae01ee7c657cc77bab5f9862abdf5a6041
 
-# Pin to the latest Ubuntu LTS for the build image base (kept current by Renovate)
-FROM ubuntu:26.04 AS build
+# Pin to the latest Ubuntu LTS for the build image base (digest-pinned, kept current by Renovate)
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b AS build
 LABEL author="sethforprivacy@protonmail.com" \
       maintainer="sethforprivacy@protonmail.com"
 
@@ -11,7 +12,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git \
     build-essential cmake libuv1-dev libzmq3-dev libsodium-dev libpgm-dev libnorm-dev \
-    libgss-dev libcurl4-openssl-dev libidn2-0-dev ca-certificates \
+    libgss-dev libcurl4-openssl-dev libidn2-dev ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -25,18 +26,20 @@ WORKDIR /p2pool
 
 # Git pull p2pool source at specified tag/branch
 ARG P2POOL_BRANCH
-RUN git clone --recursive --depth 1 --shallow-submodules --branch ${P2POOL_BRANCH} https://github.com/SChernykh/p2pool .
+ARG P2POOL_COMMIT_HASH
+RUN git clone --recursive --depth 1 --shallow-submodules --branch ${P2POOL_BRANCH} https://github.com/SChernykh/p2pool . \
+    && test `git rev-parse HEAD` = ${P2POOL_COMMIT_HASH} || exit 1
 
 # Make static p2pool binary
 ARG NPROC
 RUN test -z "$NPROC" && nproc > /nproc || echo -n "$NPROC" > /nproc && mkdir build && cd build && cmake .. && make -j"$(cat /nproc)"
 
-# Pin to the latest Ubuntu LTS for the image base (kept current by Renovate)
-FROM ubuntu:26.04
+# Pin to the latest Ubuntu LTS for the image base (digest-pinned, kept current by Renovate)
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b
 
 # Install only the runtime shared libraries that the p2pool binary links against
 # (runtime equivalents of the build-stage -dev packages, verified via ldd on the
-# built binary against the pinned Ubuntu 24.04 base)
+# built binary against the pinned Ubuntu 26.04 base)
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install --no-install-recommends -y libuv1t64 libzmq5 libsodium23 \
@@ -55,6 +58,9 @@ COPY --chown=p2pool:p2pool --from=build /p2pool/build/p2pool /usr/local/bin/p2po
 # Expose p2p and restricted RPC ports
 EXPOSE 3333
 EXPOSE 37889
+
+# Healthcheck: TCP-connect to the stratum listener; p2pool binds 0.0.0.0:3333 by default
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/3333' || exit 1
 
 # Start p2pool with required --non-interactive flag and sane defaults that are overridden by user input (if applicable)
 ENTRYPOINT ["p2pool"]

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@ A simple and straightforward Dockerized [p2pool](https://github.com/SChernykh/p2
 
 ## Actions
 
-[![Daily Update Rebuild](https://github.com/sethforprivacy/p2pool-docker//actions/workflows/update-daily.yml/badge.svg)](https://github.com/sethforprivacy/p2pool-docker/actions/workflows/update-daily.yml)  
-[![Weekly Update Rebuild](https://github.com/sethforprivacy/p2pool-docker//actions/workflows/update-base-image.yml/badge.svg)](https://github.com/sethforprivacy/p2pool-docker/actions/workflows/update-base-image.yml)  
+[![Latest Dockerfile build on push](https://github.com/sethforprivacy/p2pool-docker/actions/workflows/update-image-on-push.yml/badge.svg)](https://github.com/sethforprivacy/p2pool-docker/actions/workflows/update-image-on-push.yml)  
 
 # Docker Hub
 This repo is used to build the images available here on GHCR.
 
 # Tags
 
-`latest`: The daily rebuild from source at https://github.com/SChernykh/p2pool
+`latest`: The latest version of p2pool built from source at https://github.com/SChernykh/p2pool; the image is rebuilt only when the Dockerfile changes
 
 # Recommended usage
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       - bitmonero:/home/monero
     ports:
       - 18080:18080
-      - 18083:18083
-      - 18089:18089
+      # Container-network access suffices for p2pool; bind loopback to avoid host-wide exposure
+      - 127.0.0.1:18083:18083
+      - 127.0.0.1:18089:18089
     command:
       - "--rpc-restricted-bind-ip=0.0.0.0"
       - "--rpc-restricted-bind-port=18089"


### PR DESCRIPTION
- Pins p2pool v4.18 to commit 1748daae... with a rev-parse equality assertion (build fails on tag/commit mismatch; ARG keeps the `_COMMIT_HASH` suffix so Renovate's customManager regex still bumps branch + pin together).
- Digest-pins **ubuntu:26.04 (latest LTS)** on both stages (`sha256:2260313b...`, same digest as the hardened bitcoind/litecoind images). Package set verified live against the 26.04 base: all runtime `t64` names still exist; build-stage `libidn2-0-dev` renamed to `libidn2-dev` (updated accordingly).
- Adds HEALTHCHECK (TCP connect to stratum 3333); ports trivy CRITICAL/HIGH gate, provenance + SBOM, cosign keyless signing, digest-first push from the monerod repo.
- examples/docker-compose.yml: monerod restricted RPC 18089 + ZMQ 18083 loopback-bound only.
- Adds .dockerignore; removes dead .github/containerscan; fixes README badges/claims.
- Verified: `docker build --check` clean; YAML parse; bash -n; digests + SHAs resolved live from registry/GitHub APIs; apt-cache package probe run inside ubuntu:26.04@2260313b. Source build not run locally (heavy).